### PR TITLE
Fix event handler object modification

### DIFF
--- a/1.1.0/tokenFate.js
+++ b/1.1.0/tokenFate.js
@@ -53,12 +53,13 @@ var TokenFate = TokenFate || (function() {
 		}
 	},
 
-    handleMessages = function(msg)
+    handleMessages = function(msg_orig)
     {
 		if('api' !== msg.type ) {
 			return;
 		}
-
+	    
+	let msg = _.clone(msg_orig);
         //This sorcery shamelessly taken from The Aaron's Ammo script
         if(_.has(msg,'inlinerolls')){
 			msg.content = _.chain(msg.inlinerolls)


### PR DESCRIPTION
The Event Handlers get passed objects when events occur.  In the case of chat:message, that object is message description.  However, since Javascript defaults to Pass-By-Reference for objects, all the Event Handlers get the exact same object instance.  The practical upshot of that is that changes in one event handler will be seen by later event handlers.  This is why Ammo and other scripts that are modifying that object first make a clone of it.  It took almost a year of writing API scripts and scratching my head before I figured this out.  I'm still not sure it's well documented anywhere...
